### PR TITLE
Allow within-class token loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 *egg-info
 dist
 *.pyc
+.vscode/

--- a/cobinhood_api/__init__.py
+++ b/cobinhood_api/__init__.py
@@ -14,3 +14,9 @@ class Cobinhood(object):
         self.trading = trading.Trading(self.config)
         self.chart = chart.Chart(self.config)
         self.ws = feed.CobinhoodWS(self.config, obj=self)
+
+    def load_key(self, path):
+        """Load API token from file at path"""
+        with open(path, 'r') as f:
+            self.config.API_TOKEN = f.readline().strip()
+        return


### PR DESCRIPTION
As in [krakenx](https://github.com/veox/python3-krakenex/blob/36a66c73d97a17b0cb2cfce4872c6d4b51b5407b/krakenex/api.py#L91-L104)